### PR TITLE
FIX: Require correct branch in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - composer config repositories.behat-helper vcs https://github.com/PalatinCoder/Flowpack.Behat
     # end temp fix
     - composer config repositories.github vcs https://github.com/PalatinCoder/SquadIT.WebApp.git
-    - composer require squadit/webapp:dev-master
+    - composer require squadit/webapp:dev-$TRAVIS_PULL_REQUEST_BRANCH
     - rm -rf Packages/Application/SquadIT.WebApp
     - mv ../SquadIT.WebApp Packages/Application/SquadIT.WebApp
     - composer install -d Build/Behat


### PR DESCRIPTION
Always require the current pr's branch so that composer pulls in the
correct dependencies. For this to work, only pull requests must be
handled by travis!