### PR TITLE
TASK: Reenable continuous deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ branches:
     - master
 
 install:
+    # Variable is empty when building a push. As this only happens on master, set it preemptively
+    - if [ -z $TRAVIS_PULL_REQUEST_BRANCH ]; then export TRAVIS_PULL_REQUEST_BRANCH="master"; fi
     - cd ..
     - git clone https://github.com/neos/flow-base-distribution.git -b 3.3
     - cd flow-base-distribution

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ cache:
     directories:
         - $HOME/.composer/cache
 
+# when triggered by a push only build master branch and do deployment
+# other branches are built via pr
+branches:
+  only:
+    - master
+
 install:
     - cd ..
     - git clone https://github.com/neos/flow-base-distribution.git -b 3.3


### PR DESCRIPTION
Only build master branch if triggered by a push. Pushes to master need
to be built in order to execute the deployment afterwards. All other
branches are built via their pull requests

fixes #107