### PR TITLE
FIX: Dashboard shows only upcoming events

### DIFF
--- a/Classes/Controller/StandardController.php
+++ b/Classes/Controller/StandardController.php
@@ -20,7 +20,9 @@ class StandardController extends AbstractUserAwareActionController
 
         foreach ($this->user->getSquads() as $squad) {
             foreach ($squad->getEvents() as $event) {
-                $upcomingEvents[] = $event;
+                if ($event->getStartDate() > new \DateTime) {
+                    $upcomingEvents[] = $event;
+                }
             }
         }
 


### PR DESCRIPTION
Before, also events in the past were shown on the dashboard. With this change it is checked if the event is actually in the future.